### PR TITLE
Prevent falling through floor when leaving bed

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -115,7 +115,7 @@ for i in ipairs(beds_list) do
 				meta:set_string("player", "")
 				player_in_bed = player_in_bed-1
 			elseif meta:get_string("player") == "" then
-				pos.y = pos.y-1
+				pos.y = pos.y-0.5
 				clicker:set_physics_override(0, 0, 0)
 				clicker:setpos(pos)
 				if param2 == 0 then

--- a/init.lua
+++ b/init.lua
@@ -88,7 +88,11 @@ for i in ipairs(beds_list) do
 			if not clicker:is_player() then
 				return
 			end
+
+			local playername = clicker:get_player_name()
+
 			local meta = minetest.env:get_meta(pos)
+			local bedplayer = meta:get_string("player")
 			local param2 = node.param2
 			if param2 == 0 then
 				pos.z = pos.z+1
@@ -99,23 +103,26 @@ for i in ipairs(beds_list) do
 			elseif param2 == 3 then
 				pos.x = pos.x-1
 			end
-			if clicker:get_player_name() == meta:get_string("player") then
-				if param2 == 0 then
-					pos.x = pos.x-1
-				elseif param2 == 1 then
-					pos.z = pos.z+1
-				elseif param2 == 2 then
-					pos.x = pos.x+1
-				elseif param2 == 3 then
-					pos.z = pos.z-1
-				end
-				pos.y = pos.y-0.5
+
+			if playername == bedplayer then
+
+				clicker:setpos(beds_player_spawns[playername])
 				clicker:set_physics_override(1, 1, 1)
-				clicker:setpos(pos)
 				meta:set_string("player", "")
-				player_in_bed = player_in_bed-1
-			elseif meta:get_string("player") == "" then
-				pos.y = pos.y-0.5
+				player_in_bed = player_in_bed - 1
+
+			elseif bedplayer == "" then
+
+				-- Save the spawn position before we move the player into
+				-- the bed.
+				beds_player_spawns[playername] = clicker:getpos()
+				local file = io.open(minetest.get_worldpath().."/beds_player_spawns", "w")
+				if file then
+					file:write(minetest.serialize(beds_player_spawns))
+					file:close()
+				end
+
+				pos.y = pos.y - 1
 				clicker:set_physics_override(0, 0, 0)
 				clicker:setpos(pos)
 				if param2 == 0 then
@@ -128,8 +135,9 @@ for i in ipairs(beds_list) do
 					clicker:set_look_yaw(1.5*math.pi)
 				end
 				
-				meta:set_string("player", clicker:get_player_name())
-				player_in_bed = player_in_bed+1
+				meta:set_string("player", playername)
+				player_in_bed = player_in_bed + 1
+
 			end
 		end
 	})
@@ -211,14 +219,6 @@ minetest.register_globalstep(function(dtime)
 					wait = false
 				end)
 				wait = true
-				for _,player in ipairs(minetest.get_connected_players()) do
-					beds_player_spawns[player:get_player_name()] = player:getpos()
-				end
-				local file = io.open(minetest.get_worldpath().."/beds_player_spawns", "w")
-				if file then
-					file:write(minetest.serialize(beds_player_spawns))
-					file:close()
-				end
 			end
 		end
 	end
@@ -230,8 +230,10 @@ minetest.register_on_respawnplayer(function(player)
 		player:setpos(beds_player_spawns[name])
 		return true
 	end
+	return false
 end)
 
 if minetest.setting_get("log_mods") then
 	minetest.log("action", "beds loaded")
 end
+


### PR DESCRIPTION
Without this change, leaving a bed which is on a floor one node high
makes you fall through the floor. Additionally, sometimes (presumably
due to network lag) you would still be in the bed, which you could no
longer see, leaving you no option but to log out.
